### PR TITLE
Fix Supabase client setup for Next.js 15

### DIFF
--- a/src/app/teacher/create-test/page.tsx
+++ b/src/app/teacher/create-test/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from 'next/navigation';
 import CreateTestForm from './CreateTestForm';
 
 async function getClasses(userId: string) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from('classes')
     .select('id, name')
@@ -18,7 +18,7 @@ async function getClasses(userId: string) {
 }
 
 export default async function CreateTestPage() {
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data: { session } } = await supabase.auth.getSession();
 
   if (!session) {

--- a/src/app/teacher/page.tsx
+++ b/src/app/teacher/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
 export default async function TeacherDashboard() {
-  const supabase = createClient();
+  const supabase = await createClient();
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,7 +5,7 @@ import LogoutButton from './LogoutButton';
 
 export default async function Header() {
   // THAY ĐỔI: Không cần truyền cookies() vào nữa
-  const supabase = createClient(); 
+  const supabase = await createClient();
 
   const {
     data: { session },

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,8 +1,8 @@
 // src/lib/supabase/client.ts
-import { createBrowserClient } from '@supabase/auth-helpers-nextjs'
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 
 export const createClient = () =>
-  createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  )
+  createClientComponentClient({
+    supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  });

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,9 +1,9 @@
 // src/lib/supabase/server.ts
-import { createServerClient, type CookieOptions } from '@supabase/ssr'
-import { cookies } from 'next/headers'
+import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import { cookies } from 'next/headers';
 
-export const createClient = () => {
-  const cookieStore = cookies()
+export const createClient = async () => {
+  const cookieStore = await cookies();
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -11,11 +11,11 @@ export const createClient = () => {
     {
       cookies: {
         get(name: string) {
-          return cookieStore.get(name)?.value
+          return cookieStore.get(name)?.value;
         },
         set(name: string, value: string, options: CookieOptions) {
           try {
-            cookieStore.set({ name, value, ...options })
+            cookieStore.set({ name, value, ...options });
           } catch (error) {
             // The `set` method was called from a Server Component.
             // This can be ignored if you have middleware refreshing
@@ -24,7 +24,7 @@ export const createClient = () => {
         },
         remove(name: string, options: CookieOptions) {
           try {
-            cookieStore.set({ name, value: '', ...options })
+            cookieStore.set({ name, value: '', ...options });
           } catch (error) {
             // The `delete` method was called from a Server Component.
             // This can be ignored if you have middleware refreshing
@@ -33,5 +33,5 @@ export const createClient = () => {
         },
       },
     }
-  )
-}
+  );
+};


### PR DESCRIPTION
## Summary
- replace the deprecated Supabase browser client helper with createClientComponentClient
- await Next.js 15 cookies() when creating the Supabase server client and update server-side callers

## Testing
- npm run build *(fails: Turbopack cannot download the Inter font from Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d671dcdea08328ba378eada0567579