### PR TITLE
Ensure Supabase sign-up sends confirmation emails

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -59,10 +59,15 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const register = async (fullName: string, email: string, password: string, role: UserRole) => {
     setLoading(true);
     try {
-      const { error } = await supabase.auth.signUp({
+      const emailRedirectTo = typeof window !== 'undefined'
+        ? `${window.location.origin}/login`
+        : undefined;
+
+      const { data, error } = await supabase.auth.signUp({
         email,
         password,
         options: {
+          emailRedirectTo,
           data: {
             full_name: fullName,
             role,
@@ -70,6 +75,9 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         }
       });
       if (error) throw error;
+      if (!data?.user) {
+        throw new Error('Không thể tạo tài khoản. Vui lòng thử lại sau.');
+      }
     } catch (error) {
       console.error(error);
       throw error;

--- a/services/api.ts
+++ b/services/api.ts
@@ -22,10 +22,15 @@ const generateQuestions = async (topic: string, numQuestions: number, questionTy
 export const api = {
   // --- User & Auth ---
   register: async (fullName: string, email: string, pass: string, role: UserRole): Promise<void> => {
-    const { error } = await supabase.auth.signUp({
+    const emailRedirectTo = typeof window !== 'undefined'
+      ? `${window.location.origin}/login`
+      : undefined;
+
+    const { data, error } = await supabase.auth.signUp({
       email,
       password: pass,
       options: {
+        emailRedirectTo,
         data: {
           full_name: fullName,
           role,
@@ -33,6 +38,9 @@ export const api = {
       }
     });
     if (error) throw error;
+    if (!data?.user) {
+      throw new Error('Không thể tạo tài khoản. Vui lòng thử lại sau.');
+    }
   },
   
   login: async (email: string, pass: string): Promise<void> => {


### PR DESCRIPTION
## Summary
- add a redirect URL to Supabase sign-up calls so confirmation emails can be issued
- surface a fallback error if the sign-up API does not return a user record

## Testing
- npm run build *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a2a3e8bc8328b2ff14f5863eff3c