### PR TITLE
Resend verification email when sign-up already exists

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useEffect, ReactNode } from 'react';
-import { UserProfile } from '../types';
+import { RegistrationOutcome, UserProfile } from '../types';
 import { UserRole } from '../constants';
 import { api } from '../services/api';
 import { supabase } from '../services/supabaseClient';
@@ -10,7 +10,12 @@ interface AuthContextType {
   loading: boolean;
   login: (email: string, pass: string) => Promise<void>;
   logout: () => void;
-  register: (fullName: string, email: string, password: string, role: UserRole) => Promise<void>;
+  register: (
+    fullName: string,
+    email: string,
+    password: string,
+    role: UserRole
+  ) => Promise<RegistrationOutcome>;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -56,20 +61,15 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     }
   };
 
-  const register = async (fullName: string, email: string, password: string, role: UserRole) => {
+  const register = async (
+    fullName: string,
+    email: string,
+    password: string,
+    role: UserRole
+  ) => {
     setLoading(true);
     try {
-      const { error } = await supabase.auth.signUp({
-        email,
-        password,
-        options: {
-          data: {
-            full_name: fullName,
-            role,
-          }
-        }
-      });
-      if (error) throw error;
+      return await api.register(fullName, email, password, role);
     } catch (error) {
       console.error(error);
       throw error;

--- a/pages/Register.tsx
+++ b/pages/Register.tsx
@@ -30,8 +30,12 @@ const Register: React.FC = () => {
 
     setLoading(true);
     try {
-      await register(fullName, email, password, role);
-      setSuccess('Đăng ký thành công! Vui lòng kiểm tra email của bạn để xác nhận tài khoản trước khi đăng nhập.');
+      const result = await register(fullName, email, password, role);
+      if (result === 'resent') {
+        setSuccess('Tài khoản này đã được đăng ký trước đó nhưng chưa được xác nhận. Chúng tôi vừa gửi lại email xác nhận, vui lòng kiểm tra hộp thư của bạn.');
+      } else {
+        setSuccess('Đăng ký thành công! Vui lòng kiểm tra email của bạn để xác nhận tài khoản trước khi đăng nhập.');
+      }
     } catch (err: any) {
       setError(err.message || 'Đăng ký thất bại. Vui lòng thử lại.');
     } finally {

--- a/types.ts
+++ b/types.ts
@@ -1,6 +1,8 @@
 import { UserRole } from './constants';
 import { User } from '@supabase/supabase-js';
 
+export type RegistrationOutcome = 'created' | 'resent';
+
 export interface UserProfile extends User {
   role: UserRole;
   fullName: string;


### PR DESCRIPTION
## Summary
- add a shared registration outcome type so registration flows can react to Supabase responses consistently
- centralize AuthContext registration through the API helper and resend Supabase confirmation emails for existing unconfirmed users
- update the register page messaging to explain when a confirmation email has been resent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6a2a3e8bc8328b2ff14f5863eff3c