### PR TITLE
Improve role-based auth navigation and class creation validation

### DIFF
--- a/src/app/layout/ProtectedRoute.tsx
+++ b/src/app/layout/ProtectedRoute.tsx
@@ -24,7 +24,8 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ allowRoles, redi
   }
 
   if (allowRoles && profile && !allowRoles.includes(profile.role)) {
-    return <Navigate to="/" replace />;
+    const fallback = profile.role === 'teacher' ? '/teacher' : profile.role === 'student' ? '/student' : '/';
+    return <Navigate to={fallback} replace />;
   }
 
   return <Outlet />;

--- a/src/features/teacher/components/CreateClassForm.tsx
+++ b/src/features/teacher/components/CreateClassForm.tsx
@@ -16,12 +16,27 @@ export const CreateClassForm: React.FC<Props> = ({ onCreated }) => {
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!profile) return;
+    const sanitizedName = name.trim();
+
+    if (!profile?.id) {
+      setError('Không xác định được tài khoản giáo viên. Vui lòng đăng nhập lại.');
+      return;
+    }
+
+    if (profile.role !== 'teacher') {
+      setError('Chỉ giáo viên mới được phép tạo lớp học.');
+      return;
+    }
+
+    if (!sanitizedName) {
+      setError('Tên lớp học không được để trống.');
+      return;
+    }
 
     setLoading(true);
     setError(null);
     try {
-      const klass = await ClassApi.createClass(name, profile.id);
+      const klass = await ClassApi.createClass(sanitizedName, profile.id);
       setName('');
       onCreated(klass);
     } catch (err) {


### PR DESCRIPTION
## Summary
- update the auth context and login flow so that users land on the teacher or student dashboard based on their profile role
- simplify registration by removing the role toggle and explaining that administrators will assign roles after sign-up
- validate class creation input and profile data before calling Supabase to avoid invalid insert payloads

## Testing
- npm run build *(fails: tailwindcss dev dependency is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b6f4b8a4832889ee556a3c66f15c