### PR TITLE
Handle duplicate invite code collisions when creating classes

### DIFF
--- a/src/services/api/classes.ts
+++ b/src/services/api/classes.ts
@@ -1,3 +1,5 @@
+import type { PostgrestError } from '@supabase/supabase-js';
+
 import { ClassSummary } from '@/types';
 import { supabase } from '@/lib/supabaseClient';
 
@@ -20,20 +22,64 @@ export async function listClassesForTeacher(teacherId: string) {
   return (data ?? []).map(mapClass);
 }
 
-export async function createClass(name: string, teacherId: string) {
-  const inviteCode = Math.random().toString(36).slice(2, 8).toUpperCase();
-  const { data, error } = await supabase
-    .from('classes')
-    .insert({
-      name,
-      teacher_id: teacherId,
-      invite_code: inviteCode,
-    })
-    .select('*')
-    .single();
+const generateInviteCode = () => Math.random().toString(36).slice(2, 8).toUpperCase();
 
-  if (error) throw error;
-  return mapClass(data);
+const formatCreateClassError = (error: PostgrestError | null) => {
+  if (!error) {
+    return 'Không thể tạo lớp học.';
+  }
+
+  if (error.code === '23505') {
+    if (error.message?.includes('classes_invite_code_key')) {
+      return 'Không thể sinh mã mời duy nhất cho lớp học. Vui lòng thử lại.';
+    }
+    if (error.message?.includes('classes_teacher_id_name_key')) {
+      return 'Bạn đã có lớp học khác với tên này.';
+    }
+  }
+
+  if (error.code === '23503') {
+    return 'Không tìm thấy tài khoản giáo viên hợp lệ. Vui lòng đăng nhập lại.';
+  }
+
+  if (error.code === '42501') {
+    return 'Tài khoản hiện không có quyền tạo lớp học. Kiểm tra lại policy Supabase cho bảng classes.';
+  }
+
+  return error.message || 'Không thể tạo lớp học.';
+};
+
+export async function createClass(name: string, teacherId: string) {
+  const MAX_ATTEMPTS = 5;
+  let attempt = 0;
+
+  while (attempt < MAX_ATTEMPTS) {
+    const inviteCode = generateInviteCode();
+    const { data, error } = await supabase
+      .from('classes')
+      .insert([
+        {
+          name,
+          teacher_id: teacherId,
+          invite_code: inviteCode,
+        },
+      ])
+      .select('*')
+      .maybeSingle();
+
+    if (!error && data) {
+      return mapClass(data);
+    }
+
+    if (error?.code === '23505' && error.message?.includes('classes_invite_code_key')) {
+      attempt += 1;
+      continue;
+    }
+
+    throw new Error(formatCreateClassError(error ?? null));
+  }
+
+  throw new Error('Không thể tạo lớp học do trùng mã mời. Vui lòng thử lại sau.');
 }
 
 export async function joinClass(inviteCode: string, studentId: string) {


### PR DESCRIPTION
## Summary
- regenerate class invite codes when Supabase reports a duplicate and retry creation
- surface clearer, localized error messaging for common Supabase failures when teachers create classes

## Testing
- npm run build *(fails: missing tailwindcss module in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7451cd71483289137db00022d4e54