### PR TITLE
Apply animated gradient shell and refine dashboards

### DIFF
--- a/src/app/layout/AppShell.tsx
+++ b/src/app/layout/AppShell.tsx
@@ -9,8 +9,20 @@ export const AppShell: React.FC = () => {
   const isTeacherRoute = location.pathname.startsWith('/teacher');
 
   return (
-    <div className="min-h-screen bg-slate-100 text-slate-900">
-      <header className="sticky top-0 z-40 border-b border-slate-200/70 bg-white/80 backdrop-blur">
+    <div className="relative min-h-screen overflow-hidden text-slate-900">
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-br from-indigo-50 via-white to-sky-50" />
+        <div className="absolute -top-32 -left-24 h-[28rem] w-[28rem] rounded-full bg-gradient-to-br from-sky-300/40 to-indigo-400/40 blur-3xl animate-blob" />
+        <div
+          className="absolute top-1/3 -right-16 h-[24rem] w-[24rem] rounded-full bg-gradient-to-br from-purple-300/35 to-indigo-400/35 blur-3xl animate-blob"
+          style={{ animationDelay: '-6s' }}
+        />
+        <div
+          className="absolute bottom-[-12rem] left-1/3 h-[30rem] w-[30rem] rounded-full bg-gradient-to-br from-cyan-300/30 to-sky-400/30 blur-3xl animate-blob-slow"
+          style={{ animationDelay: '-3s' }}
+        />
+      </div>
+      <header className="sticky top-0 z-30 border-b border-slate-200/70 bg-white/80 backdrop-blur">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
           <Link to="/" className="text-xl font-semibold tracking-tight text-slate-900">
             QuizLab
@@ -51,7 +63,7 @@ export const AppShell: React.FC = () => {
           </nav>
         </div>
       </header>
-      <main className="mx-auto max-w-6xl px-6 py-12">
+      <main className="relative z-10 mx-auto max-w-6xl px-6 py-12">
         <Outlet />
       </main>
     </div>

--- a/src/features/student/pages/StudentDashboardPage.tsx
+++ b/src/features/student/pages/StudentDashboardPage.tsx
@@ -48,17 +48,17 @@ export const StudentDashboardPage: React.FC = () => {
   const { upcoming, running, completed } = useMemo(() => groupTests(tests), [tests]);
 
   const renderSection = (title: string, list: TestOverview[]) => (
-    <section>
-      <div className="flex items-center justify-between">
+    <section className="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-sm backdrop-blur">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
         <span className="text-sm text-slate-500">{list.length} bài thi</span>
       </div>
-      <div className="mt-3 grid gap-4 sm:grid-cols-2">
+      <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
         {list.map((test) => (
           <Link
             key={test.id}
             to={`/test/${test.id}`}
-            className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-indigo-200"
+            className="rounded-2xl border border-slate-200/80 bg-white/90 p-5 text-left text-sm text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-md"
           >
             <h3 className="text-base font-semibold text-slate-900">{test.title}</h3>
             <p className="mt-1 text-sm text-slate-500">
@@ -66,16 +66,24 @@ export const StudentDashboardPage: React.FC = () => {
             </p>
             <p className="mt-1 text-sm text-slate-500">Thời lượng: {test.durationMinutes} phút</p>
             {test.status === 'completed' && (
-              <p className="mt-2 text-sm font-medium text-indigo-600">
+              <p className="mt-3 text-sm font-medium text-indigo-600">
                 Đã nộp · Điểm: {test.score ?? 'đang chấm'}
               </p>
             )}
-            {test.status === 'running' && <span className="mt-2 inline-block rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">Đang diễn ra</span>}
-            {test.status === 'upcoming' && <span className="mt-2 inline-block rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-700">Sắp diễn ra</span>}
+            {test.status === 'running' && (
+              <span className="mt-3 inline-block rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">
+                Đang diễn ra
+              </span>
+            )}
+            {test.status === 'upcoming' && (
+              <span className="mt-3 inline-block rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-700">
+                Sắp diễn ra
+              </span>
+            )}
           </Link>
         ))}
         {list.length === 0 && (
-          <div className="rounded-xl border border-dashed border-slate-200 p-6 text-sm text-slate-500">
+          <div className="rounded-2xl border border-dashed border-slate-200 bg-white/70 p-6 text-sm text-slate-500">
             Chưa có bài thi nào.
           </div>
         )}
@@ -83,24 +91,81 @@ export const StudentDashboardPage: React.FC = () => {
     </section>
   );
 
+  const summary = {
+    total: tests.length,
+    running: running.length,
+    upcoming: upcoming.length,
+    completed: completed.length,
+  };
+
   return (
     <div className="space-y-10">
-      <div className="rounded-2xl border border-indigo-100 bg-gradient-to-r from-indigo-50 via-white to-purple-50 p-8 shadow-sm">
-        <h1 className="text-2xl font-semibold text-slate-900">Chào mừng trở lại!</h1>
-        <p className="mt-2 max-w-2xl text-sm text-slate-600">
-          Theo dõi các bài thi sắp diễn ra, tham gia lớp mới bằng mã mời và xem lại các bài thi đã hoàn thành.
-        </p>
-      </div>
+      <div className="grid gap-8 xl:grid-cols-[minmax(0,1.65fr)_minmax(0,1fr)]">
+        <section className="space-y-8">
+          <div className="relative overflow-hidden rounded-3xl border border-indigo-200/70 bg-gradient-to-br from-indigo-500 via-purple-500 to-sky-500 p-8 text-white shadow-xl">
+            <div className="pointer-events-none absolute -top-20 -left-16 h-72 w-72 rounded-full bg-indigo-300/40 blur-3xl animate-blob" />
+            <div
+              className="pointer-events-none absolute -bottom-24 right-1/4 h-80 w-80 rounded-full bg-sky-300/35 blur-3xl animate-blob"
+              style={{ animationDelay: '-5s' }}
+            />
+            <div className="relative space-y-4">
+              <Link
+                to="/"
+                className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.32em] text-indigo-100 transition hover:border-white/40 hover:bg-white/20"
+              >
+                QuizLab
+              </Link>
+              <h1 className="text-3xl font-semibold">Chào mừng trở lại!</h1>
+              <p className="max-w-2xl text-sm text-indigo-100/90">
+                Theo dõi các bài thi sắp diễn ra, tham gia lớp mới bằng mã mời và xem lại các bài thi đã hoàn thành.
+              </p>
+            </div>
+          </div>
 
-      <JoinClassCard onJoined={refresh} />
+          <div className="space-y-6">
+            {renderSection('Đang diễn ra', running)}
+            {renderSection('Sắp diễn ra', upcoming)}
+            {renderSection('Đã hoàn thành', completed)}
+          </div>
+        </section>
 
-      {error && <p className="text-sm text-rose-600">{error}</p>}
-      {loading && <p className="text-sm text-slate-500">Đang tải dữ liệu...</p>}
+        <aside className="space-y-6">
+          <JoinClassCard onJoined={refresh} />
 
-      <div className="space-y-8">
-        {renderSection('Đang diễn ra', running)}
-        {renderSection('Sắp diễn ra', upcoming)}
-        {renderSection('Đã hoàn thành', completed)}
+          <div className="rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm backdrop-blur">
+            <h2 className="text-base font-semibold text-slate-900">Tổng quan nhanh</h2>
+            <dl className="mt-4 grid gap-4 sm:grid-cols-2">
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-slate-500">Tổng số bài thi</dt>
+                <dd className="mt-1 text-2xl font-semibold text-slate-900">{summary.total}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-slate-500">Đang diễn ra</dt>
+                <dd className="mt-1 text-2xl font-semibold text-slate-900">{summary.running}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-slate-500">Sắp diễn ra</dt>
+                <dd className="mt-1 text-2xl font-semibold text-slate-900">{summary.upcoming}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-slate-500">Đã hoàn thành</dt>
+                <dd className="mt-1 text-2xl font-semibold text-slate-900">{summary.completed}</dd>
+              </div>
+            </dl>
+          </div>
+
+          {error && (
+            <div className="rounded-xl border border-rose-100 bg-rose-50/80 px-4 py-3 text-sm text-rose-600 shadow-sm">
+              {error}
+            </div>
+          )}
+
+          {loading && (
+            <div className="rounded-xl border border-slate-200 bg-white/80 px-4 py-3 text-sm text-slate-600 shadow-sm">
+              Đang tải dữ liệu...
+            </div>
+          )}
+        </aside>
       </div>
     </div>
   );

--- a/src/features/teacher/pages/TeacherDashboardPage.tsx
+++ b/src/features/teacher/pages/TeacherDashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import { useAuth } from '@/features/auth/context/AuthContext';
 import { CreateClassForm } from '@/features/teacher/components/CreateClassForm';
@@ -39,88 +40,131 @@ export const TeacherDashboardPage: React.FC = () => {
   }, [profile?.id]);
 
   const totalStudents = useMemo(() => classes.length * 30, [classes.length]);
+  const totalTests = useMemo(
+    () => Object.values(tests).reduce((total, list) => total + list.length, 0),
+    [tests],
+  );
 
   return (
     <div className="space-y-10">
-      <div className="rounded-2xl border border-indigo-100 bg-gradient-to-r from-indigo-600 to-purple-600 p-8 text-white shadow-sm">
-        <h1 className="text-2xl font-semibold">Bảng điều khiển giáo viên</h1>
-        <p className="mt-2 max-w-2xl text-sm text-indigo-100">
-          Tạo lớp học mới, lên lịch đề thi và theo dõi tiến độ học sinh theo thời gian thực.
-        </p>
-        <dl className="mt-6 grid gap-6 sm:grid-cols-3">
-          <div>
-            <dt className="text-xs uppercase tracking-wide text-indigo-200">Lớp học</dt>
-            <dd className="text-2xl font-semibold">{classes.length}</dd>
-          </div>
-          <div>
-            <dt className="text-xs uppercase tracking-wide text-indigo-200">Số bài thi</dt>
-            <dd className="text-2xl font-semibold">
-              {Object.values(tests).reduce((total, list) => total + list.length, 0)}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs uppercase tracking-wide text-indigo-200">Học sinh dự kiến</dt>
-            <dd className="text-2xl font-semibold">~{totalStudents}</dd>
-          </div>
-        </dl>
-      </div>
-
-      <CreateClassForm
-        onCreated={(klass) => {
-          setClasses((prev) => [klass, ...prev]);
-        }}
-      />
-
-      {classes.length > 0 ? (
-        <CreateTestForm classes={classes} onCreated={refresh} />
-      ) : (
-        <p className="text-sm text-slate-500">
-          Hãy tạo ít nhất một lớp học trước khi thêm đề thi.
-        </p>
-      )}
-
-      {error && <p className="text-sm text-rose-600">{error}</p>}
-      {loading && <p className="text-sm text-slate-500">Đang tải dữ liệu...</p>}
-
-      <section className="space-y-6">
-        <h2 className="text-lg font-semibold text-slate-900">Các lớp học của bạn</h2>
-        {classes.map((klass) => (
-          <div key={klass.id} className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-              <div>
-                <h3 className="text-base font-semibold text-slate-900">{klass.name}</h3>
-                <p className="mt-1 text-sm text-slate-500">
-                  Mã mời: <span className="font-semibold text-indigo-600">{klass.inviteCode}</span>
-                </p>
-                <p className="mt-1 text-xs text-slate-400">
-                  Tạo ngày {new Date(klass.createdAt).toLocaleDateString('vi-VN')}
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
+        <section className="space-y-6">
+          <div className="relative overflow-hidden rounded-3xl border border-indigo-200/60 bg-gradient-to-br from-indigo-600 via-indigo-500 to-purple-600 p-8 text-white shadow-xl">
+            <div className="pointer-events-none absolute -top-24 -left-20 h-80 w-80 rounded-full bg-indigo-400/30 blur-3xl animate-blob" />
+            <div
+              className="pointer-events-none absolute -bottom-32 right-1/3 h-72 w-72 rounded-full bg-sky-400/30 blur-3xl animate-blob"
+              style={{ animationDelay: '-4s' }}
+            />
+            <div className="relative space-y-6">
+              <Link
+                to="/"
+                className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-indigo-100 transition hover:border-white/40 hover:bg-white/20"
+              >
+                QuizLab
+              </Link>
+              <div className="space-y-3">
+                <h1 className="text-3xl font-semibold">Bảng điều khiển giáo viên</h1>
+                <p className="max-w-2xl text-sm text-indigo-100/90">
+                  Tạo lớp học mới, lên lịch đề thi và theo dõi tiến độ học sinh theo thời gian thực.
                 </p>
               </div>
-              <div className="space-y-3 text-sm text-slate-600">
-                <p>Bài thi đã tạo: {tests[klass.id]?.length ?? 0}</p>
-                <div className="space-y-2">
-                  {(tests[klass.id] ?? []).map((test) => (
-                    <div key={test.id} className="rounded-lg border border-slate-200 p-3 text-xs">
-                      <p className="font-semibold text-slate-700">{test.title}</p>
-                      <p className="mt-1 text-slate-500">
-                        Bắt đầu lúc {new Date(test.startTime).toLocaleString('vi-VN')} · {test.durationMinutes} phút
-                      </p>
-                    </div>
-                  ))}
-                  {(tests[klass.id] ?? []).length === 0 && (
-                    <p className="text-xs text-slate-400">Chưa có bài thi nào cho lớp này.</p>
-                  )}
+              <dl className="grid gap-4 sm:grid-cols-3">
+                <div className="rounded-2xl border border-white/10 bg-white/10 p-4">
+                  <dt className="text-xs uppercase tracking-wide text-indigo-100/80">Lớp học</dt>
+                  <dd className="mt-2 text-2xl font-semibold">{classes.length}</dd>
                 </div>
-              </div>
+                <div className="rounded-2xl border border-white/10 bg-white/10 p-4">
+                  <dt className="text-xs uppercase tracking-wide text-indigo-100/80">Số bài thi</dt>
+                  <dd className="mt-2 text-2xl font-semibold">{totalTests}</dd>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-white/10 p-4">
+                  <dt className="text-xs uppercase tracking-wide text-indigo-100/80">Học sinh dự kiến</dt>
+                  <dd className="mt-2 text-2xl font-semibold">~{totalStudents}</dd>
+                </div>
+              </dl>
             </div>
           </div>
-        ))}
-        {classes.length === 0 && (
-          <div className="rounded-xl border border-dashed border-slate-200 p-6 text-sm text-slate-500">
-            Bạn chưa có lớp học nào. Hãy tạo lớp đầu tiên ngay!
-          </div>
-        )}
-      </section>
+
+          <section className="space-y-4">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <h2 className="text-lg font-semibold text-slate-900">Các lớp học của bạn</h2>
+              <span className="text-sm text-slate-600">{classes.length} lớp đang hoạt động</span>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              {classes.map((klass) => (
+                <div
+                  key={klass.id}
+                  className="flex h-full flex-col justify-between rounded-2xl border border-slate-200/70 bg-white/80 p-6 shadow-sm backdrop-blur"
+                >
+                  <div className="space-y-2">
+                    <h3 className="text-base font-semibold text-slate-900">{klass.name}</h3>
+                    <p className="text-sm text-slate-500">
+                      Mã mời: <span className="font-semibold text-indigo-600">{klass.inviteCode}</span>
+                    </p>
+                    <p className="text-xs text-slate-400">
+                      Tạo ngày {new Date(klass.createdAt).toLocaleDateString('vi-VN')}
+                    </p>
+                  </div>
+                  <div className="mt-4 space-y-3 text-sm text-slate-600">
+                    <p className="font-medium text-slate-700">Bài thi đã tạo: {tests[klass.id]?.length ?? 0}</p>
+                    <div className="space-y-2">
+                      {(tests[klass.id] ?? []).map((test) => (
+                        <div
+                          key={test.id}
+                          className="rounded-xl border border-slate-200/80 bg-white/70 p-3 text-xs shadow-sm"
+                        >
+                          <p className="font-semibold text-slate-800">{test.title}</p>
+                          <p className="mt-1 text-slate-500">
+                            Bắt đầu lúc {new Date(test.startTime).toLocaleString('vi-VN')} · {test.durationMinutes} phút
+                          </p>
+                        </div>
+                      ))}
+                      {(tests[klass.id] ?? []).length === 0 && (
+                        <p className="rounded-lg border border-dashed border-slate-200 bg-white/60 p-3 text-xs text-slate-400">
+                          Chưa có bài thi nào cho lớp này.
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+            {classes.length === 0 && (
+              <div className="rounded-2xl border border-dashed border-slate-300 bg-white/70 p-6 text-sm text-slate-600 shadow-sm">
+                Bạn chưa có lớp học nào. Hãy tạo lớp đầu tiên ngay!
+              </div>
+            )}
+          </section>
+        </section>
+
+        <aside className="space-y-6">
+          <CreateClassForm
+            onCreated={(klass) => {
+              setClasses((prev) => [klass, ...prev]);
+            }}
+          />
+
+          {classes.length > 0 ? (
+            <CreateTestForm classes={classes} onCreated={refresh} />
+          ) : (
+            <div className="rounded-2xl border border-slate-200 bg-white/80 p-6 text-sm text-slate-600 shadow-sm">
+              Hãy tạo ít nhất một lớp học trước khi thêm đề thi.
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-xl border border-rose-100 bg-rose-50/80 px-4 py-3 text-sm text-rose-600 shadow-sm">
+              {error}
+            </div>
+          )}
+
+          {loading && (
+            <div className="rounded-xl border border-slate-200 bg-white/80 px-4 py-3 text-sm text-slate-600 shadow-sm">
+              Đang tải dữ liệu...
+            </div>
+          )}
+        </aside>
+      </div>
     </div>
   );
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,5 +7,20 @@
 }
 
 body {
-  @apply bg-slate-100 text-slate-900 antialiased;
+  @apply min-h-screen text-slate-900 antialiased;
+  background-image: linear-gradient(120deg, #eef2ff, #faf5ff, #e0f2fe, #ede9fe);
+  background-size: 260% 260%;
+  animation: global-gradient 26s ease-in-out infinite;
+}
+
+@keyframes global-gradient {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
 }


### PR DESCRIPTION
## Summary
- apply the homepage-inspired animated gradient overlay globally so every route shares the same motion background
- update the teacher dashboard with a responsive two-column layout, richer class cards, and a QuizLab shortcut back to the homepage
- reorganize the student dashboard with flexible sections, quick stats, and home navigation on the hero card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7b08d8cc88328ba7170a7353c2a60