### PR TITLE
Adjust hero layout and personalize student greeting

### DIFF
--- a/src/features/student/pages/StudentDashboardPage.tsx
+++ b/src/features/student/pages/StudentDashboardPage.tsx
@@ -98,6 +98,8 @@ export const StudentDashboardPage: React.FC = () => {
     completed: completed.length,
   };
 
+  const studentName = profile?.fullName?.trim();
+
   return (
     <div className="space-y-10">
       <div className="grid gap-8 xl:grid-cols-[minmax(0,1.65fr)_minmax(0,1fr)]">
@@ -115,7 +117,17 @@ export const StudentDashboardPage: React.FC = () => {
               >
                 QuizLab
               </Link>
-              <h1 className="text-3xl font-semibold">Chào mừng trở lại!</h1>
+              <h1 className="text-3xl font-semibold text-white">
+                Chào mừng trở lại
+                {studentName ? (
+                  <>
+                    {' '}
+                    <span className="text-amber-200">{studentName}</span>!
+                  </>
+                ) : (
+                  '!'
+                )}
+              </h1>
               <p className="max-w-2xl text-sm text-indigo-100/90">
                 Theo dõi các bài thi sắp diễn ra, tham gia lớp mới bằng mã mời và xem lại các bài thi đã hoàn thành.
               </p>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { useAuth } from '@/features/auth/context/AuthContext';
@@ -123,16 +123,6 @@ export const HomePage: React.FC = () => {
     }
   ];
 
-  const stats = useMemo(
-    () => [
-      { label: 'Kỳ thi đã tổ chức', value: '4.200+' },
-      { label: 'Thời gian chờ trung bình', value: '02:15"' },
-      { label: 'Học sinh tham gia', value: '18.000+' },
-      { label: 'Tỉ lệ nộp bài đúng giờ', value: '98%' }
-    ],
-    []
-  );
-
   const heroHeading =
     'Phòng thi trực tuyến sắc nét, truyền cảm hứng sáng tạo';
   const heroDescription =
@@ -154,41 +144,31 @@ export const HomePage: React.FC = () => {
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.2),_transparent_55%)]" />
         </div>
 
-        <div className="flex flex-col gap-12 lg:flex-row lg:items-center lg:justify-between">
-          <div className="space-y-6 lg:max-w-xl">
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/25 bg-white/20 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-white/90">
-              QuizLab
-            </span>
-            <div className="space-y-4">
-              <h1 className="text-4xl font-semibold leading-tight tracking-tight text-white sm:text-5xl lg:text-6xl">
-                <TypedText text={heroHeading} />
-              </h1>
-              <p className="max-w-2xl text-lg text-white/90">
-                <TypedText text={heroDescription} typingSpeed={45} deleteSpeed={30} pause={2200} />
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-4">
-              <Link
-                to="/login"
-                className="rounded-full bg-white px-6 py-3 text-sm font-semibold text-indigo-700 transition hover:bg-indigo-100"
-              >
-                Bắt đầu miễn phí
-              </Link>
-              <a
-                href="#features"
-                className="rounded-full border border-white/50 px-6 py-3 text-sm font-semibold text-white transition hover:border-white hover:bg-white/10"
-              >
-                Xem tính năng
-              </a>
-            </div>
+        <div className="mx-auto max-w-3xl space-y-6">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/25 bg-white/20 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-white/90">
+            QuizLab
+          </span>
+          <div className="space-y-4">
+            <h1 className="text-4xl font-semibold leading-tight tracking-tight text-white sm:text-5xl lg:text-6xl">
+              <TypedText text={heroHeading} />
+            </h1>
+            <p className="text-lg text-white/90">
+              <TypedText text={heroDescription} typingSpeed={45} deleteSpeed={30} pause={2200} />
+            </p>
           </div>
-
-          <div className="flex w-full max-w-md flex-col gap-4 text-left text-white/90 lg:max-w-lg">
-            {stats.map((stat) => (
-              <p key={stat.label} className="text-lg font-medium">
-                <TypedText text={`${stat.label}: ${stat.value}`} typingSpeed={80} deleteSpeed={45} pause={2000} />
-              </p>
-            ))}
+          <div className="flex flex-wrap gap-4">
+            <Link
+              to="/login"
+              className="rounded-full bg-white px-6 py-3 text-sm font-semibold text-indigo-700 transition hover:bg-indigo-100"
+            >
+              Bắt đầu miễn phí
+            </Link>
+            <a
+              href="#features"
+              className="rounded-full border border-white/50 px-6 py-3 text-sm font-semibold text-white transition hover:border-white hover:bg-white/10"
+            >
+              Xem tính năng
+            </a>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- simplify the home page hero by removing the animated stats column and centering the main copy within a tighter container
- keep the hero call-to-action buttons aligned beneath the primary text for a cleaner composition
- personalize the student dashboard welcome banner by appending the logged-in student's name in a contrasting accent color

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7bfefd5948328be11449e4adf13bc