### PR TITLE
Guard dashboard API calls when profile ids are missing

### DIFF
--- a/src/features/student/pages/StudentDashboardPage.tsx
+++ b/src/features/student/pages/StudentDashboardPage.tsx
@@ -28,6 +28,11 @@ export const StudentDashboardPage: React.FC = () => {
 
   const refresh = async () => {
     if (!profile) return;
+    if (!profile.id) {
+      setError('Không xác định được tài khoản học sinh. Vui lòng đăng nhập lại.');
+      setTests([]);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/features/teacher/pages/TeacherDashboardPage.tsx
+++ b/src/features/teacher/pages/TeacherDashboardPage.tsx
@@ -68,6 +68,13 @@ export const TeacherDashboardPage: React.FC = () => {
 
   const refresh = async () => {
     if (!profile) return;
+    if (!profile.id) {
+      setError('Không xác định được tài khoản giáo viên. Vui lòng đăng nhập lại.');
+      setClasses([]);
+      setSubjects([]);
+      setTests({});
+      return;
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/services/api/classes.ts
+++ b/src/services/api/classes.ts
@@ -12,6 +12,10 @@ const mapClass = (row: any): ClassSummary => ({
 });
 
 export async function listClassesForTeacher(teacherId: string) {
+  if (!teacherId) {
+    throw new Error('Không xác định được tài khoản giáo viên. Vui lòng đăng nhập lại.');
+  }
+
   const { data, error } = await supabase
     .from('classes')
     .select('*')

--- a/src/services/api/subjects.ts
+++ b/src/services/api/subjects.ts
@@ -11,6 +11,10 @@ const mapSubject = (row: any): SubjectSummary => ({
 });
 
 export async function listSubjectsForTeacher(teacherId: string) {
+  if (!teacherId) {
+    throw new Error('Không xác định được tài khoản giáo viên. Vui lòng đăng nhập lại.');
+  }
+
   const { data, error } = await supabase
     .from('subjects')
     .select('*')

--- a/src/services/api/tests.ts
+++ b/src/services/api/tests.ts
@@ -43,6 +43,10 @@ export async function fetchTest(testId: string): Promise<TestDetail | null> {
 }
 
 export async function listTestsForStudent(studentId: string): Promise<TestOverview[]> {
+  if (!studentId) {
+    throw new Error('Không xác định được tài khoản học sinh. Vui lòng đăng nhập lại.');
+  }
+
   const { data: enrollments, error: enrollmentError } = await supabase
     .from('enrollments')
     .select('class_id')


### PR DESCRIPTION
## Summary
- prevent teacher and student dashboards from calling Supabase when the authenticated profile is missing an id and surface a clearer error message
- add runtime checks in class, subject, and student test API helpers so we avoid issuing malformed requests when the user id is absent

## Testing
- npm run build *(fails: rollup optional dependency @rollup/rollup-linux-x64-gnu is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ce28be1c83289e64fb5abd5dbb52